### PR TITLE
Fix the issue of install Python 2.7

### DIFF
--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -89,9 +89,13 @@ jobs:
       - name: Install essential packages
         run: |
           sudo apt-get update
-          sudo apt-get install swig python2-dev
+          sudo apt-get install swig
           echo 'switch to python2 as default'
           sudo rm /usr/bin/python
+          wget https://www.python.org/ftp/python/2.7.18/Python-2.7.18.tar.xz
+          tar -xJf Python-2.7.18.tar.xz
+          cd Python-2.7.18
+          ./configure && sudo make && sudo make install
           sudo ln -s /usr/bin/python2 /usr/bin/python
 
       - name: Download OpenWrt toolchain


### PR DESCRIPTION
Fix the issue where GitHub Workflow (Ubuntu 22.04) cannot install Python 2.7